### PR TITLE
Feature/add bsipa as dependency

### DIFF
--- a/MorePrecisePlayerHeight/manifest.json
+++ b/MorePrecisePlayerHeight/manifest.json
@@ -5,7 +5,7 @@
   "description": "Let's you view your own height... but more precise.",
   "author": "Eris",
   "gameVersion": "1.11.0",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "dependsOn": {
     "BSIPA": "^4.0.0"
   }

--- a/MorePrecisePlayerHeight/manifest.json
+++ b/MorePrecisePlayerHeight/manifest.json
@@ -5,5 +5,8 @@
   "description": "Let's you view your own height... but more precise.",
   "author": "Eris",
   "gameVersion": "1.11.0",
-  "version": "1.1.2"
+  "version": "1.1.2",
+  "dependsOn": {
+    "BSIPA": "^4.0.0"
+  }
 }


### PR DESCRIPTION
Added BSIPA as a dependency because... it has always need BSIPA in order to be loaded in correctly (and @nike4613 asked it kindly 😅)